### PR TITLE
Families implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 # Container with application
-FROM amazoncorretto:11.0.3
+FROM amazoncorretto:11.0.4
 COPY /build/install/kotbot /kotbot
 ENTRYPOINT /kotbot/bin/kotbot

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/Bot.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/Bot.kt
@@ -14,12 +14,13 @@ import org.telegram.telegrambots.meta.exceptions.TelegramApiException
  */
 fun startBot(
     configuration: BotConfiguration,
-    rules: List<Rule>
+    rules: List<Rule>,
+    state: State
 ): ShutdownBot {
     try {
         ApiContextInitializer.init()
         val bot = TelegramBotsApi()
-            .registerBot(KotBot(configuration, rules))
+            .registerBot(KotBot(configuration, rules, state))
         LOGGER.info("${configuration.name} started.")
         return bot::stop
     } catch (e: TelegramApiException) {

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/BotQueries.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/BotQueries.kt
@@ -1,0 +1,7 @@
+package io.heapy.kotbot.bot
+
+interface BotQueries {
+    fun getBotUser(): Pair<Int, String>
+    fun isAdminUser(chatId: Long, userId: Int): Boolean
+    fun getChatName(chatId: Long): String
+}

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/BotQueries.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/BotQueries.kt
@@ -1,5 +1,8 @@
 package io.heapy.kotbot.bot
 
+/**
+ * Provides a way to execute idempotent queries against messenger authority.
+ */
 interface BotQueries {
     fun getBotUser(): Pair<Int, String>
     fun isAdminUser(chatId: Long, userId: Int): Boolean

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/BotStore.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/BotStore.kt
@@ -8,7 +8,3 @@ class Family(
     val chatIds: MutableList<Long>,
     val adminChatId: Long
 )
-
-class Chat(
-
-)

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/BotStore.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/BotStore.kt
@@ -1,9 +1,16 @@
 package io.heapy.kotbot.bot
 
+/**
+ * Holds essential part of bot state, which should persist between restarts.
+ */
 interface BotStore {
     val families: MutableList<Family>
 }
 
+/**
+ * Represents a family of chats. Chat family is a group of chats sharing policies, restrictions, admin list.
+ * Family contains a list of corresponding [chatIds] and an [adminChatId].
+ */
 class Family(
     val chatIds: MutableList<Long>,
     val adminChatId: Long

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/BotStore.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/BotStore.kt
@@ -1,0 +1,14 @@
+package io.heapy.kotbot.bot
+
+interface BotStore {
+    val families: MutableList<Family>
+}
+
+class Family(
+    val chatIds: MutableList<Long>,
+    val adminChatId: Long
+)
+
+class Chat(
+
+)

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/InMemoryStore.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/InMemoryStore.kt
@@ -1,0 +1,5 @@
+package io.heapy.kotbot.bot
+
+class InMemoryStore : BotStore {
+    override val families: MutableList<Family> = mutableListOf()
+}

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/InMemoryStore.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/InMemoryStore.kt
@@ -1,5 +1,8 @@
 package io.heapy.kotbot.bot
 
+/**
+ * Represents [BotStore] backed by in-memory structure. It is not persistent.
+ */
 class InMemoryStore : BotStore {
     override val families: MutableList<Family> = mutableListOf()
 }

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/KotBot.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/KotBot.kt
@@ -1,36 +1,44 @@
 package io.heapy.kotbot.bot
 
-import io.heapy.kotbot.bot.rule.Action
-import io.heapy.kotbot.bot.rule.DeleteMessageAction
-import io.heapy.kotbot.bot.rule.KickUserAction
-import io.heapy.kotbot.bot.rule.Rule
-import io.heapy.logging.debug
-import io.heapy.logging.logger
+import io.heapy.kotbot.bot.rule.*
+import io.heapy.logging.*
 import org.telegram.telegrambots.bots.TelegramLongPollingBot
 import org.telegram.telegrambots.meta.api.methods.groupadministration.KickChatMember
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.DeleteMessage
 import org.telegram.telegrambots.meta.api.objects.Update
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup
+import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException
 
 /**
  * @author Ruslan Ibragimov
  */
 class KotBot(
     private val configuration: BotConfiguration,
-    private val rules: List<Rule>
+    private val rules: List<Rule>,
+    private val state: State
 ) : TelegramLongPollingBot() {
     override fun getBotToken() = configuration.token
     override fun getBotUsername() = configuration.name
+
+    private val queries = TelegramApiQueries(this).also {
+        val (botUserId, botUserName) = it.getBotUser()
+        state.botUserId = botUserId
+        state.botUserName = botUserName
+        LOGGER.info { "Bot info: @${botUserName} [${botUserId}]" }
+    }
 
     override fun onUpdateReceived(update: Update) {
         LOGGER.debug { update.toString() }
 
         rules
-            .flatMap { rule -> rule.validate(update) }
+            .flatMap { rule -> rule.validate(update, queries) }
             .distinct()
             .forEach(::executeAction)
     }
 
-    internal fun executeAction(action: Action): Unit = when (action) {
+    internal fun executeAction(action: Action): Unit = try {
+        when (action) {
             is DeleteMessageAction -> {
                 execute(DeleteMessage(action.chatId, action.messageId))
                 Unit
@@ -39,6 +47,26 @@ class KotBot(
                 execute(KickChatMember(action.chatId, action.userId))
                 Unit
             }
+            is SendMessageAction -> {
+                execute(SendMessage(action.chatId, action.text).also {
+                    if(action.inlineKeyboard != null) {
+                        it.replyMarkup = InlineKeyboardMarkup().apply { keyboard = action.inlineKeyboard }
+                    }
+                })
+                Unit
+            }
+        }
+    } catch (e: TelegramApiRequestException) {
+        val code = TelegramError.byCode(e.errorCode)
+        when {
+            code == TelegramError.BadRequest && action is ChatAction -> {
+                // assuming the bot is not an admin, repeat the action later
+                state.deferAction(action.chatId, action)
+            }
+            else -> LOGGER.error(e) { "Unable to execute action $action, errorCode: ${e.errorCode}" }
+        }
+    } catch (e: Exception) {
+        LOGGER.error(e) { "Unable to execute action $action" }
     }
 
     companion object {

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/KotBot.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/KotBot.kt
@@ -3,6 +3,7 @@ package io.heapy.kotbot.bot
 import io.heapy.kotbot.bot.rule.*
 import io.heapy.logging.*
 import org.telegram.telegrambots.bots.TelegramLongPollingBot
+import org.telegram.telegrambots.meta.api.methods.ForwardMessage
 import org.telegram.telegrambots.meta.api.methods.groupadministration.KickChatMember
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.DeleteMessage
@@ -41,11 +42,9 @@ class KotBot(
         when (action) {
             is DeleteMessageAction -> {
                 execute(DeleteMessage(action.chatId, action.messageId))
-                Unit
             }
             is KickUserAction -> {
                 execute(KickChatMember(action.chatId, action.userId))
-                Unit
             }
             is SendMessageAction -> {
                 execute(SendMessage(action.chatId, action.text).also {
@@ -53,9 +52,12 @@ class KotBot(
                         it.replyMarkup = InlineKeyboardMarkup().apply { keyboard = action.inlineKeyboard }
                     }
                 })
-                Unit
+            }
+            is ForwardMessageAction -> {
+                execute(ForwardMessage(action.chatId, action.fromChatId, action.messageId))
             }
         }
+        Unit
     } catch (e: TelegramApiRequestException) {
         val code = TelegramError.byCode(e.errorCode)
         when {

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/State.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/State.kt
@@ -1,0 +1,14 @@
+package io.heapy.kotbot.bot
+
+import io.heapy.kotbot.bot.rule.Action
+
+class State {
+    var botUserId: Int = 0
+    lateinit var botUserName: String
+    val familyAddRequests: MutableMap<String, Family> = mutableMapOf()
+    val deferredActions: MutableMap<Long, MutableList<Action>> = mutableMapOf()
+
+    fun deferAction(chatId: Long, action: Action) {
+        deferredActions.getOrPut(chatId) { mutableListOf() } += action
+    }
+}

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/State.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/State.kt
@@ -2,6 +2,10 @@ package io.heapy.kotbot.bot
 
 import io.heapy.kotbot.bot.rule.Action
 
+/**
+ * Holds nonessential part of current bot state. Should be mostly used to store information
+ * needed between processing a sequence of interconnected updates.
+ */
 class State {
     var botUserId: Int = 0
     lateinit var botUserName: String

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/TelegramApiQueries.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/TelegramApiQueries.kt
@@ -5,6 +5,9 @@ import org.telegram.telegrambots.meta.api.methods.groupadministration.GetChat
 import org.telegram.telegrambots.meta.api.methods.groupadministration.GetChatMember
 import org.telegram.telegrambots.meta.bots.AbsSender
 
+/**
+ * Provides [BotQueries] implementation for Telegram API.
+ */
 class TelegramApiQueries(private val api: AbsSender): BotQueries {
     override fun getBotUser(): Pair<Int, String> {
         val bot = api.execute(GetMe())

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/TelegramApiQueries.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/TelegramApiQueries.kt
@@ -1,0 +1,24 @@
+package io.heapy.kotbot.bot
+
+import org.telegram.telegrambots.meta.api.methods.GetMe
+import org.telegram.telegrambots.meta.api.methods.groupadministration.GetChat
+import org.telegram.telegrambots.meta.api.methods.groupadministration.GetChatMember
+import org.telegram.telegrambots.meta.bots.AbsSender
+
+class TelegramApiQueries(private val api: AbsSender): BotQueries {
+    override fun getBotUser(): Pair<Int, String> {
+        val bot = api.execute(GetMe())
+        return bot.id to bot.userName
+    }
+
+    override fun isAdminUser(chatId: Long, userId: Int): Boolean {
+        val member = api.execute(GetChatMember().also {
+            it.chatId = chatId.toString()
+            it.userId = userId
+        })
+        val status = member.status
+        return status == "creator" || status == "administrator"
+    }
+
+    override fun getChatName(chatId: Long): String = api.execute(GetChat(chatId)).title
+}

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/TelegramError.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/TelegramError.kt
@@ -1,0 +1,11 @@
+package io.heapy.kotbot.bot
+
+enum class TelegramError(val code: Int) {
+    BadRequest(400);
+
+    companion object {
+        private val values = values()
+
+        fun byCode(code: Int): TelegramError? = values.firstOrNull { it.code == code }
+    }
+}

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/randomString.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/randomString.kt
@@ -1,0 +1,11 @@
+package io.heapy.kotbot.bot
+
+import kotlin.random.Random
+
+private val charPool = ('A'..'Z') + ('a'..'z') + ('0'..'9')
+
+fun randomString(length: Int, random: Random = Random): String =
+    (1..length)
+        .map { random.nextInt(charPool.size) }
+        .map { charPool[it] }
+        .joinToString("")

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/Actions.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/Actions.kt
@@ -3,24 +3,38 @@ package io.heapy.kotbot.bot.rule
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton
 
 /**
+ * Represents an action, which can be invoked by the [Rule] during processing an update.
  * @author Ruslan Ibragimov
  */
 sealed class Action
 
+/**
+ * Represents an [Action] connected to a chat. Can be retried if previous invocation failed.
+ */
 sealed class ChatAction : Action() {
     abstract val chatId: Long
 }
 
+/**
+ * An [Action] which deletes message [messageId] from chat [chatId].
+ */
 data class DeleteMessageAction(
     override val chatId: Long,
     val messageId: Int
 ) : ChatAction()
 
+/**
+ * An [Action] which kicks user [userId] from chat [chatId].
+ */
 data class KickUserAction(
     override val chatId: Long,
     val userId: Int
 ) : ChatAction()
 
+/**
+ * An [Action] which sends message [text], optionally having buttons as an [inlineKeyboard], to chat [chatId].
+ * TODO: abstract away inline keyboard.
+ */
 data class SendMessageAction(
     override val chatId: Long,
     val text: String,

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/Actions.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/Actions.kt
@@ -1,16 +1,28 @@
 package io.heapy.kotbot.bot.rule
 
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton
+
 /**
  * @author Ruslan Ibragimov
  */
 sealed class Action
 
+sealed class ChatAction : Action() {
+    abstract val chatId: Long
+}
+
 data class DeleteMessageAction(
-    val chatId: Long,
+    override val chatId: Long,
     val messageId: Int
-) : Action()
+) : ChatAction()
 
 data class KickUserAction(
-    val chatId: Long,
+    override val chatId: Long,
     val userId: Int
-) : Action()
+) : ChatAction()
+
+data class SendMessageAction(
+    override val chatId: Long,
+    val text: String,
+    val inlineKeyboard: List<List<InlineKeyboardButton>>? = null
+): ChatAction()

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/Actions.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/Actions.kt
@@ -40,3 +40,12 @@ data class SendMessageAction(
     val text: String,
     val inlineKeyboard: List<List<InlineKeyboardButton>>? = null
 ): ChatAction()
+
+/**
+ * An [Action] which forwards message [messageId] from chat [fromChatId] to chat [chatId].
+ */
+data class ForwardMessageAction(
+    override val chatId: Long,
+    val fromChatId: Long,
+    val messageId: Int
+): ChatAction()

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/DevRules.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/DevRules.kt
@@ -1,0 +1,31 @@
+package io.heapy.kotbot.bot.rule
+
+import io.heapy.kotbot.bot.BotStore
+import org.telegram.telegrambots.meta.api.objects.Update
+
+class GetIdRule(private val store: BotStore) : Rule {
+    override fun validate(update: Update): List<Action> {
+        if(!update.hasMessage()) return emptyList()
+        val message = update.message
+        if(!message.hasText()) return emptyList()
+        val text = message.text
+        val chat = message.chat
+        return when {
+            text == "/getid" -> {
+                listOf(
+                    DeleteMessageAction(chat.id, message.messageId),
+                    SendMessageAction(chat.id, "Chat id for \"${chat.title}\" is ${chat.id}")
+                )
+            }
+            text.startsWith("/adm ") -> {
+                val admMsg = "@${message.from.userName}: ${text.substring("/adm ".length)}"
+                listOf(DeleteMessageAction(chat.id, message.messageId)) +
+                    store.families
+                        .filter { it.chatIds.contains(chat.id) }
+                        .map { SendMessageAction(it.adminChatId, admMsg) }
+            }
+            else -> emptyList()
+        }
+    }
+}
+

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/DevRules.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/DevRules.kt
@@ -3,15 +3,21 @@ package io.heapy.kotbot.bot.rule
 import io.heapy.kotbot.bot.BotStore
 import io.heapy.kotbot.bot.State
 
+/**
+ * Command `/getid` (admin): responds with current chat id.
+ */
 fun getIdRule(state: State) : Rule = adminCommandRule("/getid", state) { _, message, _ ->
     val chat = message.chat
     val chatId = chat.id
     listOf(
         DeleteMessageAction(chatId, message.messageId),
-        SendMessageAction(chatId, "Chat id for \"${chat.title}\" is ${chatId}")
+        SendMessageAction(chatId, "Chat id for \"${chat.title}\" is $chatId")
     )
 }
 
+/**
+ * Command `/adm message`: sends the message to family administrator chat.
+ */
 fun admRule(store: BotStore, state: State) : Rule = commandRule("/adm", state) { args, message, _ ->
     val admMsg = "@${message.from.userName}: $args"
     val chatId = message.chat.id
@@ -21,6 +27,9 @@ fun admRule(store: BotStore, state: State) : Rule = commandRule("/adm", state) {
                 .map { SendMessageAction(it.adminChatId, admMsg) }
 }
 
+/**
+ * A group of commands useful for development purposes.
+ */
 fun devRules(store: BotStore, state: State) = compositeRule(
     getIdRule(state),
     admRule(store, state)

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/FamilyRules.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/FamilyRules.kt
@@ -8,178 +8,183 @@ enum class FamilyCallbacks {
     RefreshAdminPermissions
 }
 
-class ReportRule(private val store: BotStore) : Rule {
-    override fun validate(update: Update): List<Action> {
-        if(!update.hasMessage()) return emptyList()
-        val message = update.message
-        if(!message.hasText()) return emptyList()
-        if(!message.text.startsWith("/report")) return emptyList()
-        val chat = message.chat
-        val family = store.families.firstOrNull { message.chatId in it.chatIds }
-        if(family == null) return emptyList()
-        val chatTitle = "\"${chat.title}\""
-        val chatMention = chat.userName?.let { "$chatTitle (@$it)" } ?: chatTitle
-        return listOf(
-            SendMessageAction(family.adminChatId, "Report sent by @${message.from.userName} in $chatMention")
+fun reportRule(store: BotStore, state: State) = commandRule("/report", state) { _, message, _ ->
+    val chat = message.chat
+    val family = store.families
+        .firstOrNull { message.chatId in it.chatIds }
+        ?: return@commandRule emptyList()
+    val chatTitle = "\"${chat.title}\""
+    val chatMention = chat.userName?.let { "$chatTitle (@$it)" } ?: chatTitle
+    listOf(
+        SendMessageAction(
+            family.adminChatId,
+            "Report sent by @${message.from.userName} in $chatMention"
         )
-    }
+    )
 }
 
-class RefreshPermissionsCallbackRule(private val state: State) : Rule {
-    override fun validate(update: Update, queries: BotQueries): List<Action> {
-        if(!update.hasCallbackQuery()) return emptyList()
-        val callback = update.callbackQuery
-        if(callback.data != FamilyCallbacks.RefreshAdminPermissions.name) return emptyList()
+fun refreshPermissionsCallbackRule(state: State) = callbackQueryRule { callback, _ ->
+    if(callback.data != FamilyCallbacks.RefreshAdminPermissions.name)
+        emptyList()
+    else
         // TODO should definitely get family and retry actions only for it
-        return state.deferredActions.values.flatten()
-    }
+        state.deferredActions.values.flatten()
 }
 
-class FamilyLeaveRule(private val store: BotStore, private val state: State) : Rule {
-    override fun validate(update: Update): List<Action> {
-        if(!update.hasMessage()) return emptyList()
-        val message = update.message
-        val chat = message.chat
-        val chatId = chat.id
-        val leftChatMember = message.leftChatMember
-        if(leftChatMember == null || leftChatMember.id != state.botUserId) return emptyList()
-        val family = store.families.firstOrNull { chatId in it.chatIds }
-        if(family == null) return emptyList()
-        family.chatIds.remove(chatId)
-        return listOf(
+fun familyStartRule(state: State) = commandRule("/start", state) { args, message, queries ->
+    val startText = "/start@${state.botUserName}"
+
+    val messageId = message.messageId
+    val chatId = message.chat.id
+    val chatTitle = "\"${message.chat.title}\""
+    val from = message.from
+    val text = message.text
+    val hash = text.substring(startText.length + 1)
+    val family = state.familyAddRequests[hash]
+
+    when {
+        family == null -> listOf(
+            SendMessageAction(chatId, "The request is expired, please try again!")
+        )
+        chatId in family.chatIds -> listOf(
+            DeleteMessageAction(chatId, messageId),
             SendMessageAction(
                 family.adminChatId,
-                "Chat \"${chat.title}\" left the family as the bot was removed from it :(")
+                "Picked chat $chatTitle is already a member " +
+                        "of this family, please pick another one")
+        )
+        !queries.isAdminUser(chatId, from.id) -> listOf(
+            SendMessageAction(
+                family.adminChatId,
+                "Sorry, @${from.userName}, you are not an admin in $chatTitle")
+        )
+        else -> {
+            family.chatIds += chatId
+            val deleteAction = DeleteMessageAction(chatId, messageId)
+            if(!queries.isAdminUser(chatId, state.botUserId)) {
+                state.deferAction(chatId, deleteAction)
+                listOf(
+                    SendMessageAction(
+                        family.adminChatId,
+                        "Chat $chatTitle is now a member of the family! Don't forget " +
+                                "to give the bot admin rights :)",
+                        listOf(
+                            listOf(
+                                InlineKeyboardButton("Admin rights granted").apply {
+                                    callbackData = FamilyCallbacks.RefreshAdminPermissions.name
+                                }
+                            )
+                        )
+                    )
+                )
+            } else {
+                listOf(
+                    deleteAction,
+                    SendMessageAction(
+                        family.adminChatId,
+                        "Chat $chatTitle is now a member of the family!")
+                )
+            }
+        }
+    }
+}
+
+fun familyLeaveRule(store: BotStore, state: State) = rule { update, _ ->
+    if(!update.hasMessage()) return@rule emptyList()
+    val message = update.message
+    val chat = message.chat
+    val chatId = chat.id
+    val leftChatMember = message.leftChatMember
+    if(leftChatMember == null || leftChatMember.id != state.botUserId)
+        return@rule emptyList()
+    val family = store.families
+        .firstOrNull { chatId in it.chatIds }
+        ?: return@rule emptyList()
+    family.chatIds.remove(chatId)
+    listOf(
+        SendMessageAction(
+            family.adminChatId,
+            "Chat \"${chat.title}\" left the family as the bot was removed from it :("
+        )
+    )
+}
+
+fun familyCreateRule(store: BotStore, state: State) = adminCommandRule("/family", state) { _, message, queries ->
+    val chatId = message.chatId
+    when {
+        chatId in store.families.map { it.adminChatId } -> listOf(
+            SendMessageAction(chatId, "This chat is already bound to the family")
+        )
+        else -> {
+            store.families.add(Family(mutableListOf(), chatId))
+            listOf(
+                SendMessageAction(chatId,
+                    "This chat is now a family admin!\n" +
+                            "Use `/family-add` to add other chats to the family")
+            )
+        }
+    }
+}
+
+fun familyListRule(store: BotStore, state: State) = adminCommandRule("/family_list", state) { _, message, queries ->
+    val chatId = message.chatId
+    val family = store.families.firstOrNull { it.adminChatId == chatId }
+    if (family == null) {
+        listOf(
+            SendMessageAction(
+                chatId,
+                "Didn't find family of this chat :(\n" +
+                        "Use `/family` to create a new one!"
+            )
+        )
+    } else {
+        listOf(
+            SendMessageAction(
+                chatId,
+                family.chatIds.map(queries::getChatName).joinToString(
+                    prefix = "Chats in our family:\n- ",
+                    separator = "\n-")
+            )
         )
     }
 }
 
-class FamilyStartRule(private val state: State) : Rule {
-    private val startText by lazy { "/start@${state.botUserName}" }
-
-    override fun validate(update: Update, queries: BotQueries): List<Action> {
-        if(!update.hasMessage()) return emptyList()
-        val message = update.message
-        if(!message.hasText()) return emptyList()
-        val messageId = message.messageId
-        val chatId = message.chat.id
-        val chatTitle = "\"${message.chat.title}\""
-        val from = message.from
-        val text = message.text
-        return when {
-            text.startsWith(startText) -> {
-                val hash = text.substring(startText.length + 1)
-                val family = state.familyAddRequests[hash]
-                when {
-                    family == null -> listOf(SendMessageAction(chatId,
-                        "The request is expired, please try again!"))
-                    chatId in family.chatIds -> listOf(
-                        DeleteMessageAction(chatId, messageId),
-                        SendMessageAction(family.adminChatId,
-                            "Picked chat $chatTitle is already a member " +
-                                    "of this family, please pick another one"))
-                    !queries.isAdminUser(chatId, from.id) -> listOf(SendMessageAction(family.adminChatId,
-                        "Sorry, @${from.userName}, you are not an admin in $chatTitle"))
-                    else -> {
-                        family.chatIds += chatId
-                        val deleteAction = DeleteMessageAction(chatId, messageId)
-                        if(!queries.isAdminUser(chatId, state.botUserId)) {
-                            state.deferAction(chatId, deleteAction)
-                            listOf(SendMessageAction(
-                                family.adminChatId,
-                                "Chat $chatTitle is now a member of the family! Don't forget " +
-                                        "to give the bot admin rights :)",
-                                listOf(listOf(
-                                    InlineKeyboardButton("Admin rights granted").apply {
-                                        callbackData = FamilyCallbacks.RefreshAdminPermissions.name
-                                    }
-                                )))
-                            )
-                        } else {
-                            listOf(
-                                deleteAction,
-                                SendMessageAction(family.adminChatId,
-                                    "Chat $chatTitle is now a member of the family!"))
-                        }
+fun familyAddRule(store: BotStore, state: State) = adminCommandRule("/family_add", state) { _, message, queries ->
+    val chatId = message.chatId
+    val family = store.families.firstOrNull { it.adminChatId == chatId }
+    if (family == null) {
+        listOf(
+            SendMessageAction(
+                chatId,
+                "Didn't find family of this chat :(\n" +
+                        "Use `/family` to create a new one!"
+            )
+        )
+    } else {
+        val hash = randomString(32)
+        state.familyAddRequests[hash] = family
+        listOf(
+            SendMessageAction(
+                chatId,
+                "Please pick the chat to add: https://telegram.me/${state.botUserName}?startgroup=$hash\n" +
+                        "Note that you must be an admin in that chat!"
+                /*listOf(listOf(
+                    InlineKeyboardButton("Cancel").apply {
+                        callbackData = "..."
                     }
-                }
-            }
-            else -> emptyList()
-        }
+                ))*/
+            )
+        )
     }
 }
 
-class FamilyManageRule(private val store: BotStore, private val state: State) : Rule {
-    override fun validate(update: Update, queries: BotQueries): List<Action> {
-        if(!update.hasMessage()) return emptyList()
-        val message = update.message
-        if(!message.hasText()) return emptyList()
-        val chatId = message.chatId
-        val isAdmin = queries.isAdminUser(chatId, message.from.id)
-        return when(message.text) {
-            "/family" -> {
-                when {
-                    !isAdmin -> listOf(DeleteMessageAction(chatId, message.messageId))
-                    chatId in store.families.map { it.adminChatId } ->
-                        listOf(SendMessageAction(chatId, "This chat is already bound to the family"))
-                    else -> {
-                        store.families.add(Family(mutableListOf(), chatId))
-                        listOf(SendMessageAction(chatId,
-                            "This chat is now a family admin!\n" +
-                                    "Use `/family-add` to add other chats to the family"))
-                    }
-                }
-            }
-            "/family-list" -> {
-                val family = store.families.firstOrNull { it.adminChatId == chatId }
-                if (family == null) {
-                    listOf(
-                        SendMessageAction(
-                            chatId,
-                            "Didn't find family of this chat :(\n" +
-                                    "Use `/family` to create a new one!"
-                        )
-                    )
-                } else {
-                    listOf(
-                        SendMessageAction(
-                            chatId,
-                            family.chatIds.map(queries::getChatName).joinToString(
-                                prefix = "Chats in our family:\n- ",
-                                separator = "\n-")
-                        )
-                    )
-                }
-            }
-            "/family-add" -> {
-                val family = store.families.firstOrNull { it.adminChatId == chatId }
-                if (family == null) {
-                    listOf(
-                        SendMessageAction(
-                            chatId,
-                            "Didn't find family of this chat :(\n" +
-                                    "Use `/family` to create a new one!"
-                        )
-                    )
-                } else {
-                    val hash = randomString(32)
-                    state.familyAddRequests[hash] = family
-                    listOf(
-                        DeleteMessageAction(chatId, message.messageId),
-                        SendMessageAction(
-                            chatId,
-                            "Please pick the chat to add: https://telegram.me/${state.botUserName}?startgroup=$hash\n" +
-                                    "Note that you must be an admin in that chat!"
-                            /*listOf(listOf(
-                                InlineKeyboardButton("Cancel").apply {
-                                    callbackData = "..."
-                                }
-                            ))*/
-                        )
-                    )
-                }
-            }
-            else -> emptyList()
-        }
-    }
-}
+fun familyRules(store: BotStore, state: State) = compositeRule(
+    reportRule(store, state),
+    refreshPermissionsCallbackRule(state),
+    familyStartRule(state),
+    familyLeaveRule(store, state),
+
+    familyCreateRule(store, state),
+    familyListRule(store, state),
+    familyAddRule(store, state)
+)

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/FamilyRules.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/FamilyRules.kt
@@ -1,0 +1,185 @@
+package io.heapy.kotbot.bot.rule
+
+import io.heapy.kotbot.bot.*
+import org.telegram.telegrambots.meta.api.objects.Update
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton
+
+enum class FamilyCallbacks {
+    RefreshAdminPermissions
+}
+
+class ReportRule(private val store: BotStore) : Rule {
+    override fun validate(update: Update): List<Action> {
+        if(!update.hasMessage()) return emptyList()
+        val message = update.message
+        if(!message.hasText()) return emptyList()
+        if(!message.text.startsWith("/report")) return emptyList()
+        val chat = message.chat
+        val family = store.families.firstOrNull { message.chatId in it.chatIds }
+        if(family == null) return emptyList()
+        val chatTitle = "\"${chat.title}\""
+        val chatMention = chat.userName?.let { "$chatTitle (@$it)" } ?: chatTitle
+        return listOf(
+            SendMessageAction(family.adminChatId, "Report sent by @${message.from.userName} in $chatMention")
+        )
+    }
+}
+
+class RefreshPermissionsCallbackRule(private val state: State) : Rule {
+    override fun validate(update: Update, queries: BotQueries): List<Action> {
+        if(!update.hasCallbackQuery()) return emptyList()
+        val callback = update.callbackQuery
+        if(callback.data != FamilyCallbacks.RefreshAdminPermissions.name) return emptyList()
+        // TODO should definitely get family and retry actions only for it
+        return state.deferredActions.values.flatten()
+    }
+}
+
+class FamilyLeaveRule(private val store: BotStore, private val state: State) : Rule {
+    override fun validate(update: Update): List<Action> {
+        if(!update.hasMessage()) return emptyList()
+        val message = update.message
+        val chat = message.chat
+        val chatId = chat.id
+        val leftChatMember = message.leftChatMember
+        if(leftChatMember == null || leftChatMember.id != state.botUserId) return emptyList()
+        val family = store.families.firstOrNull { chatId in it.chatIds }
+        if(family == null) return emptyList()
+        family.chatIds.remove(chatId)
+        return listOf(
+            SendMessageAction(
+                family.adminChatId,
+                "Chat \"${chat.title}\" left the family as the bot was removed from it :(")
+        )
+    }
+}
+
+class FamilyStartRule(private val state: State) : Rule {
+    private val startText by lazy { "/start@${state.botUserName}" }
+
+    override fun validate(update: Update, queries: BotQueries): List<Action> {
+        if(!update.hasMessage()) return emptyList()
+        val message = update.message
+        if(!message.hasText()) return emptyList()
+        val messageId = message.messageId
+        val chatId = message.chat.id
+        val chatTitle = "\"${message.chat.title}\""
+        val from = message.from
+        val text = message.text
+        return when {
+            text.startsWith(startText) -> {
+                val hash = text.substring(startText.length + 1)
+                val family = state.familyAddRequests[hash]
+                when {
+                    family == null -> listOf(SendMessageAction(chatId,
+                        "The request is expired, please try again!"))
+                    chatId in family.chatIds -> listOf(
+                        DeleteMessageAction(chatId, messageId),
+                        SendMessageAction(family.adminChatId,
+                            "Picked chat $chatTitle is already a member " +
+                                    "of this family, please pick another one"))
+                    !queries.isAdminUser(chatId, from.id) -> listOf(SendMessageAction(family.adminChatId,
+                        "Sorry, @${from.userName}, you are not an admin in $chatTitle"))
+                    else -> {
+                        family.chatIds += chatId
+                        val deleteAction = DeleteMessageAction(chatId, messageId)
+                        if(!queries.isAdminUser(chatId, state.botUserId)) {
+                            state.deferAction(chatId, deleteAction)
+                            listOf(SendMessageAction(
+                                family.adminChatId,
+                                "Chat $chatTitle is now a member of the family! Don't forget " +
+                                        "to give the bot admin rights :)",
+                                listOf(listOf(
+                                    InlineKeyboardButton("Admin rights granted").apply {
+                                        callbackData = FamilyCallbacks.RefreshAdminPermissions.name
+                                    }
+                                )))
+                            )
+                        } else {
+                            listOf(
+                                deleteAction,
+                                SendMessageAction(family.adminChatId,
+                                    "Chat $chatTitle is now a member of the family!"))
+                        }
+                    }
+                }
+            }
+            else -> emptyList()
+        }
+    }
+}
+
+class FamilyManageRule(private val store: BotStore, private val state: State) : Rule {
+    override fun validate(update: Update, queries: BotQueries): List<Action> {
+        if(!update.hasMessage()) return emptyList()
+        val message = update.message
+        if(!message.hasText()) return emptyList()
+        val chatId = message.chatId
+        val isAdmin = queries.isAdminUser(chatId, message.from.id)
+        return when(message.text) {
+            "/family" -> {
+                when {
+                    !isAdmin -> listOf(DeleteMessageAction(chatId, message.messageId))
+                    chatId in store.families.map { it.adminChatId } ->
+                        listOf(SendMessageAction(chatId, "This chat is already bound to the family"))
+                    else -> {
+                        store.families.add(Family(mutableListOf(), chatId))
+                        listOf(SendMessageAction(chatId,
+                            "This chat is now a family admin!\n" +
+                                    "Use `/family-add` to add other chats to the family"))
+                    }
+                }
+            }
+            "/family-list" -> {
+                val family = store.families.firstOrNull { it.adminChatId == chatId }
+                if (family == null) {
+                    listOf(
+                        SendMessageAction(
+                            chatId,
+                            "Didn't find family of this chat :(\n" +
+                                    "Use `/family` to create a new one!"
+                        )
+                    )
+                } else {
+                    listOf(
+                        SendMessageAction(
+                            chatId,
+                            family.chatIds.map(queries::getChatName).joinToString(
+                                prefix = "Chats in our family:\n- ",
+                                separator = "\n-")
+                        )
+                    )
+                }
+            }
+            "/family-add" -> {
+                val family = store.families.firstOrNull { it.adminChatId == chatId }
+                if (family == null) {
+                    listOf(
+                        SendMessageAction(
+                            chatId,
+                            "Didn't find family of this chat :(\n" +
+                                    "Use `/family` to create a new one!"
+                        )
+                    )
+                } else {
+                    val hash = randomString(32)
+                    state.familyAddRequests[hash] = family
+                    listOf(
+                        DeleteMessageAction(chatId, message.messageId),
+                        SendMessageAction(
+                            chatId,
+                            "Please pick the chat to add: https://telegram.me/${state.botUserName}?startgroup=$hash\n" +
+                                    "Note that you must be an admin in that chat!"
+                            /*listOf(listOf(
+                                InlineKeyboardButton("Cancel").apply {
+                                    callbackData = "..."
+                                }
+                            ))*/
+                        )
+                    )
+                }
+            }
+            else -> emptyList()
+        }
+    }
+}

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/PolicyRules.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/PolicyRules.kt
@@ -1,0 +1,83 @@
+package io.heapy.kotbot.bot.rule
+
+import io.heapy.kotbot.bot.*
+import java.net.URL
+
+val deleteJoinRule = rule { update, _ ->
+    if (!update.message?.newChatMembers.isNullOrEmpty()) {
+        LOGGER.info("Delete joined users message ${update.message.newChatMembers}")
+        listOf(DeleteMessageAction(update.message.chatId, update.message.messageId))
+    } else {
+        listOf()
+    }
+}
+
+fun deleteHelloRule(strings: List<String>) = rule { update, _ ->
+    update.anyText { text, message ->
+        if (strings.contains(text.toLowerCase())) {
+            LOGGER.info("Delete hello message ${message.text}")
+            return@rule listOf(DeleteMessageAction(message.chatId, message.messageId))
+        }
+    }
+
+    listOf()
+}
+
+val defaultDeleteHelloRule = deleteHelloRule(listOf(
+    "hi",
+    "hello",
+    "привет"
+))
+
+fun deleteSwearingRule(regexs: List<Regex>) = rule { update, _ ->
+    update.anyText { text, message ->
+        val normalizedText = text.toLowerCase()
+        val isSwearing = regexs.any { normalizedText.contains(it) }
+        if (isSwearing) {
+            LOGGER.info("Delete message with swearing ${message.text}")
+            return@rule listOf(DeleteMessageAction(message.chatId, message.messageId))
+        }
+    }
+
+    listOf()
+}
+
+internal fun wordRegex(word: String) = Regex("(?i)\\b$word\\b")
+
+fun resourceDeleteSwearingRule(url: URL) = deleteSwearingRule(
+    url.readText()
+        .split("\n")
+        .filter { it.isNotEmpty() }
+        .map(::wordRegex))
+
+val deleteSpamRule = rule { update, _ ->
+    update.anyText { text, message ->
+        val kick = when {
+            text.contains("t.me/joinchat/") -> {
+                LOGGER.info("Delete message with join link ${message.text}")
+                true
+            }
+            text.contains("t.cn/") -> {
+                LOGGER.info("Delete message with t.cn link ${message.text}")
+                true
+            }
+            else -> false
+        }
+
+        if (kick) {
+            return@rule listOf(
+                DeleteMessageAction(message.chatId, message.messageId),
+                KickUserAction(message.chatId, message.from.id)
+            )
+        }
+    }
+
+    listOf()
+}
+
+fun policyRules(swearingResource: URL?) = compositeRule(
+    deleteJoinRule,
+    deleteSpamRule,
+    defaultDeleteHelloRule,
+    swearingResource?.let(::resourceDeleteSwearingRule)
+)

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/Rules.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/Rules.kt
@@ -12,16 +12,25 @@ interface Rule {
     fun validate(update: Update, queries: BotQueries): List<Action>
 }
 
+/**
+ * Creates generic rule for processing incoming messages and events.
+ */
 fun rule(rule: (Update, BotQueries) -> List<Action>): Rule =
     object : Rule {
         override fun validate(update: Update, queries: BotQueries): List<Action> =
             rule(update, queries)
     }
 
+/**
+ * Creates rule which applies all passed [rules] sequentially.
+ */
 fun compositeRule(vararg rules: Rule?): Rule = rule { update, queries ->
-    rules.filterNotNull().map { it.validate(update, queries) }.flatten()
+    rules.mapNotNull { it?.validate(update, queries) }.flatten()
 }
 
+/**
+ * Creates rule processing incoming [CallbackQuery] (result of pressing callback button, inline keyboard button, etc).
+ */
 fun callbackQueryRule(rule: (CallbackQuery, BotQueries) -> List<Action>): Rule = rule { update, queries ->
     if(!update.hasCallbackQuery())
         emptyList()
@@ -29,6 +38,11 @@ fun callbackQueryRule(rule: (CallbackQuery, BotQueries) -> List<Action>): Rule =
         rule(update.callbackQuery, queries)
 }
 
+/**
+ * Creates rule processing commands. A command is a message of the following format:
+ *
+ * `/command_name command_args...`
+ */
 fun commandRule(rule: (Message, BotQueries) -> List<Action>): Rule = rule { update, queries ->
     if(!update.hasMessage() ||
         !update.message.hasText() ||
@@ -37,20 +51,30 @@ fun commandRule(rule: (Message, BotQueries) -> List<Action>): Rule = rule { upda
     else rule(update.message, queries)
 }
 
+/**
+ * Creates rule processing command named [commandText]. Handles both commands with and without bot username appended.
+ */
 fun commandRule(commandText: String, state: State, rule: (String, Message, BotQueries) -> List<Action>): Rule =
-    commandRule rule@ { message, queries ->
-        val text = message.text
-        if(!text.startsWith(commandText)) return@rule emptyList()
-        val botSuffix = "@${state.botUserName}"
-        val args = text.substring(commandText.length)
-        val filteredArgs = if(args.startsWith(botSuffix)) {
-            args.substring(botSuffix.length + 1)
-        } else {
-            args
+    if(commandText.length > COMMAND_NAME_MAX_LENGTH)
+        error("Command name must not be more than $COMMAND_NAME_MAX_LENGTH characters long.")
+    else
+        commandRule rule@ { message, queries ->
+            val text = message.text
+            if(!text.startsWith(commandText)) return@rule emptyList()
+            val botSuffix = "@${state.botUserName}"
+            val args = text.substring(commandText.length)
+            val filteredArgs = if(args.startsWith(botSuffix)) {
+                args.substring(botSuffix.length + 1)
+            } else {
+                args
+            }
+            rule(filteredArgs, message, queries)
         }
-        rule(filteredArgs, message, queries)
-    }
 
+/**
+ * Creates rule processing command named [commandText]. Validates that the user invoking the command is an administrator
+ * of the chat where the command is invoked.
+ */
 fun adminCommandRule(commandText: String, state: State, rule: (String, Message, BotQueries) -> List<Action>) : Rule =
     commandRule(commandText, state) { args, message, queries ->
         if(queries.isAdminUser(message.chatId, message.from.id)) {
@@ -59,5 +83,7 @@ fun adminCommandRule(commandText: String, state: State, rule: (String, Message, 
             listOf(DeleteMessageAction(message.chatId, message.messageId))
         }
     }
+
+private val COMMAND_NAME_MAX_LENGTH = 32
 
 internal val LOGGER = logger<Rule>()

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/Rules.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/Rules.kt
@@ -1,5 +1,6 @@
 package io.heapy.kotbot.bot.rule
 
+import io.heapy.kotbot.bot.BotQueries
 import io.heapy.kotbot.bot.anyText
 import io.heapy.logging.logger
 import org.telegram.telegrambots.meta.api.objects.Update
@@ -8,7 +9,8 @@ import org.telegram.telegrambots.meta.api.objects.Update
  * @author Ruslan Ibragimov
  */
 interface Rule {
-    fun validate(update: Update): List<Action>
+    fun validate(update: Update): List<Action> = emptyList()
+    fun validate(update: Update, queries: BotQueries): List<Action> = validate(update)
 }
 
 private val LOGGER = logger<Rule>()

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/Rules.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/Rules.kt
@@ -1,102 +1,135 @@
 package io.heapy.kotbot.bot.rule
 
-import io.heapy.kotbot.bot.BotQueries
-import io.heapy.kotbot.bot.anyText
+import io.heapy.kotbot.bot.*
 import io.heapy.logging.logger
-import org.telegram.telegrambots.meta.api.objects.Update
+import org.telegram.telegrambots.meta.api.objects.*
+import java.net.URL
 
 /**
  * @author Ruslan Ibragimov
  */
 interface Rule {
-    fun validate(update: Update): List<Action> = emptyList()
-    fun validate(update: Update, queries: BotQueries): List<Action> = validate(update)
+    fun validate(update: Update, queries: BotQueries): List<Action>
 }
+
+fun rule(rule: (Update, BotQueries) -> List<Action>): Rule =
+    object : Rule {
+        override fun validate(update: Update, queries: BotQueries): List<Action> =
+            rule(update, queries)
+    }
+
+fun compositeRule(vararg rules: Rule): Rule = rule { update, queries ->
+    rules.map { it.validate(update, queries) }.flatten()
+}
+
+fun callbackQueryRule(rule: (CallbackQuery, BotQueries) -> List<Action>): Rule = rule { update, queries ->
+    if(!update.hasCallbackQuery())
+        emptyList()
+    else
+        rule(update.callbackQuery, queries)
+}
+
+fun commandRule(rule: (Message, BotQueries) -> List<Action>): Rule = rule { update, queries ->
+    if(!update.hasMessage() ||
+        !update.message.hasText() ||
+        !update.message.text.startsWith("/"))
+        emptyList()
+    else rule(update.message, queries)
+}
+
+fun commandRule(commandText: String, state: State, rule: (String, Message, BotQueries) -> List<Action>): Rule =
+    commandRule rule@ { message, queries ->
+        val text = message.text
+        if(!text.startsWith(commandText)) return@rule emptyList()
+        val botSuffix = "@${state.botUserName}"
+        val args = text.substring(commandText.length)
+        val filteredArgs = if(args.startsWith(botSuffix)) {
+            args.substring(botSuffix.length + 1)
+        } else {
+            args
+        }
+        rule(filteredArgs, message, queries)
+    }
+
+fun adminCommandRule(commandText: String, state: State, rule: (String, Message, BotQueries) -> List<Action>) : Rule =
+    commandRule(commandText, state) { args, message, queries ->
+        if(queries.isAdminUser(message.chatId, message.from.id)) {
+            rule(args, message, queries)
+        } else {
+            listOf(DeleteMessageAction(message.chatId, message.messageId))
+        }
+    }
 
 private val LOGGER = logger<Rule>()
 
-class DeleteJoinRule : Rule {
-    override fun validate(update: Update): List<Action> {
-        if (!update.message?.newChatMembers.isNullOrEmpty()) {
-            LOGGER.info("Delete joined users message ${update.message.newChatMembers}")
-            return listOf(DeleteMessageAction(update.message.chatId, update.message.messageId))
-        }
-
-        return listOf()
+val deleteJoinRule = rule { update, _ ->
+    if (!update.message?.newChatMembers.isNullOrEmpty()) {
+        LOGGER.info("Delete joined users message ${update.message.newChatMembers}")
+        listOf(DeleteMessageAction(update.message.chatId, update.message.messageId))
+    } else {
+        listOf()
     }
 }
 
-class DeleteHelloRule : Rule {
-    override fun validate(update: Update): List<Action> {
-        update.anyText { text, message ->
-            if (strings.contains(text.toLowerCase())) {
-                LOGGER.info("Delete hello message ${message.text}")
-                return listOf(DeleteMessageAction(message.chatId, message.messageId))
-            }
+fun deleteHelloRule(strings: List<String>) = rule { update, _ ->
+    update.anyText { text, message ->
+        if (strings.contains(text.toLowerCase())) {
+            LOGGER.info("Delete hello message ${message.text}")
+            return@rule listOf(DeleteMessageAction(message.chatId, message.messageId))
         }
-
-        return listOf()
     }
 
-    companion object {
-        private val strings = listOf(
-            "hi",
-            "hello",
-            "привет"
-        )
-    }
+    listOf()
 }
 
-class DeleteSwearingRule : Rule {
-    override fun validate(update: Update): List<Action> {
-        update.anyText { text, message ->
-            val normalizedText = text.toLowerCase()
-            val isSwearing = strings.any { normalizedText.contains(it) }
-            if (isSwearing) {
-                LOGGER.info("Delete message with swearing ${message.text}")
-                return listOf(DeleteMessageAction(message.chatId, message.messageId))
-            }
+val defaultDeleteHelloRule = deleteHelloRule(listOf(
+    "hi",
+    "hello",
+    "привет"
+))
+
+fun deleteSwearingRule(regexs: List<Regex>) = rule { update, _ ->
+    update.anyText { text, message ->
+        val normalizedText = text.toLowerCase()
+        val isSwearing = regexs.any { normalizedText.contains(it) }
+        if (isSwearing) {
+            LOGGER.info("Delete message with swearing ${message.text}")
+            return@rule listOf(DeleteMessageAction(message.chatId, message.messageId))
         }
-
-        return listOf()
     }
 
-    companion object {
-        internal fun wordRegex(word: String) = Regex("(?i)\\b$word\\b")
-
-        private val strings = DeleteSwearingRule::class.java.classLoader
-            .getResource("contains.txt")
-            ?.readText()
-            ?.split("\n")
-            ?.filter { it.isNotEmpty() }
-            ?.map(::wordRegex)
-            ?: listOf()
-    }
+    listOf()
 }
 
-class DeleteSpamRule : Rule {
-    override fun validate(update: Update): List<Action> {
-        update.anyText { text, message ->
-            val kick = when {
-                text.contains("t.me/joinchat/") -> {
-                    LOGGER.info("Delete message with join link ${message.text}")
-                    true
-                }
-                text.contains("t.cn/") -> {
-                    LOGGER.info("Delete message with t.cn link ${message.text}")
-                    true
-                }
-                else -> false
-            }
+internal fun wordRegex(word: String) = Regex("(?i)\\b$word\\b")
 
-            if (kick) {
-                return listOf(
-                    DeleteMessageAction(message.chatId, message.messageId),
-                    KickUserAction(message.chatId, message.from.id)
-                )
+fun resourceDeleteSwearingRule(url: URL) = deleteSwearingRule(
+    url.readText()
+        .split("\n")
+        .filter { it.isNotEmpty() }
+        .map(::wordRegex))
+
+val deleteSpamRule = rule { update, _ ->
+    update.anyText { text, message ->
+        val kick = when {
+            text.contains("t.me/joinchat/") -> {
+                LOGGER.info("Delete message with join link ${message.text}")
+                true
             }
+            text.contains("t.cn/") -> {
+                LOGGER.info("Delete message with t.cn link ${message.text}")
+                true
+            }
+            else -> false
         }
 
-        return listOf()
+        if (kick) {
+            return@rule listOf(
+                DeleteMessageAction(message.chatId, message.messageId),
+                KickUserAction(message.chatId, message.from.id)
+            )
+        }
     }
+
+    listOf()
 }

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/Rules.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/rule/Rules.kt
@@ -18,8 +18,8 @@ fun rule(rule: (Update, BotQueries) -> List<Action>): Rule =
             rule(update, queries)
     }
 
-fun compositeRule(vararg rules: Rule): Rule = rule { update, queries ->
-    rules.map { it.validate(update, queries) }.flatten()
+fun compositeRule(vararg rules: Rule?): Rule = rule { update, queries ->
+    rules.filterNotNull().map { it.validate(update, queries) }.flatten()
 }
 
 fun callbackQueryRule(rule: (CallbackQuery, BotQueries) -> List<Action>): Rule = rule { update, queries ->
@@ -60,76 +60,4 @@ fun adminCommandRule(commandText: String, state: State, rule: (String, Message, 
         }
     }
 
-private val LOGGER = logger<Rule>()
-
-val deleteJoinRule = rule { update, _ ->
-    if (!update.message?.newChatMembers.isNullOrEmpty()) {
-        LOGGER.info("Delete joined users message ${update.message.newChatMembers}")
-        listOf(DeleteMessageAction(update.message.chatId, update.message.messageId))
-    } else {
-        listOf()
-    }
-}
-
-fun deleteHelloRule(strings: List<String>) = rule { update, _ ->
-    update.anyText { text, message ->
-        if (strings.contains(text.toLowerCase())) {
-            LOGGER.info("Delete hello message ${message.text}")
-            return@rule listOf(DeleteMessageAction(message.chatId, message.messageId))
-        }
-    }
-
-    listOf()
-}
-
-val defaultDeleteHelloRule = deleteHelloRule(listOf(
-    "hi",
-    "hello",
-    "привет"
-))
-
-fun deleteSwearingRule(regexs: List<Regex>) = rule { update, _ ->
-    update.anyText { text, message ->
-        val normalizedText = text.toLowerCase()
-        val isSwearing = regexs.any { normalizedText.contains(it) }
-        if (isSwearing) {
-            LOGGER.info("Delete message with swearing ${message.text}")
-            return@rule listOf(DeleteMessageAction(message.chatId, message.messageId))
-        }
-    }
-
-    listOf()
-}
-
-internal fun wordRegex(word: String) = Regex("(?i)\\b$word\\b")
-
-fun resourceDeleteSwearingRule(url: URL) = deleteSwearingRule(
-    url.readText()
-        .split("\n")
-        .filter { it.isNotEmpty() }
-        .map(::wordRegex))
-
-val deleteSpamRule = rule { update, _ ->
-    update.anyText { text, message ->
-        val kick = when {
-            text.contains("t.me/joinchat/") -> {
-                LOGGER.info("Delete message with join link ${message.text}")
-                true
-            }
-            text.contains("t.cn/") -> {
-                LOGGER.info("Delete message with t.cn link ${message.text}")
-                true
-            }
-            else -> false
-        }
-
-        if (kick) {
-            return@rule listOf(
-                DeleteMessageAction(message.chatId, message.messageId),
-                KickUserAction(message.chatId, message.from.id)
-            )
-        }
-    }
-
-    listOf()
-}
+internal val LOGGER = logger<Rule>()

--- a/bot/src/main/kotlin/io/heapy/kotbot/bot/utils/tgutils.kt
+++ b/bot/src/main/kotlin/io/heapy/kotbot/bot/utils/tgutils.kt
@@ -1,0 +1,20 @@
+package io.heapy.kotbot.bot.utils
+
+import org.telegram.telegrambots.meta.api.objects.*
+
+private val T_ME = "https://t.me/"
+
+val Chat.publicLink: String?
+    get() = userName?.let { "$T_ME$it" }
+
+val Message.publicLink: String?
+    get() = if(!chat.isChannelChat && !chat.isSuperGroupChat) null else chat.userName?.let { "$T_ME$it/$messageId" }
+
+val User.publicLink: String?
+    get() = userName?.let { "$T_ME$it" }
+
+val User.fullName: String
+    get() = "$firstName $lastName"
+
+val User.fullRef: String
+    get() = userName?.let { "$fullName (@$it)" } ?: fullName

--- a/bot/src/test/kotlin/io/heapy/kotbot/bot/rule/RulesTests.kt
+++ b/bot/src/test/kotlin/io/heapy/kotbot/bot/rule/RulesTests.kt
@@ -1,6 +1,5 @@
 package io.heapy.kotbot.bot.rule
 
-import io.heapy.kotbot.bot.rule.DeleteSwearingRule.Companion.wordRegex
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test

--- a/devops/.env-template
+++ b/devops/.env-template
@@ -1,4 +1,4 @@
-# Execute `echo "$(id -u):$(id -g)"` to get TGTO_SYSTEM_USER value
+# Execute `echo "$(id -u):$(id -g)"` to get KOTBOT_SYSTEM_USER value
 
 KOTBOT_RELEASE=b42
 KOTBOT_OPTS="-Xmx256m"

--- a/devops/.env-template-dev
+++ b/devops/.env-template-dev
@@ -1,3 +1,1 @@
-# Execute `echo "$(id -u):$(id -g)"` to get TGTO_SYSTEM_USER value
-
 KOTBOT_TOKEN=id:secret

--- a/devops/docker-compose.yml
+++ b/devops/docker-compose.yml
@@ -1,27 +1,21 @@
-version: "3.3"
+version: "2.4"
 services:
   kotbot:
     image: heapy/kotbot:${KOTBOT_RELEASE}
     container_name: kotbot
     restart: always
     volumes:
-     - ${KOTBOT_DATA}/logs:/root/vol/logs/
+     - ${KOTBOT_DATA}/db/:/kotbot/db/
     environment:
       KOTBOT_OPTS: ${KOTBOT_OPTS}
       KOTBOT_TOKEN: ${KOTBOT_TOKEN}
       KOTBOT_RELEASE: ${KOTBOT_RELEASE}
-    depends_on:
-     - kotbot_database
-  kotbot_database:
-    image: postgres:10.5
-    container_name: kotbot_database
-    restart: always
-    user: "${KOTBOT_SYSTEM_USER}"
-    environment:
-      POSTGRES_PASSWORD: "kotbot"
-      POSTGRES_USER: "kotbot"
-      POSTGRES_DB: "kotbot"
-    volumes:
-     - ${KOTBOT_DATA}/pgdata:/var/lib/postgresql/data
-     - /etc/passwd:/etc/passwd:ro
-
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    logging:
+      driver: "journald"
+    mem_limit: 256m
+    mem_swappiness: 0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -5,7 +5,7 @@
 @rem you may not use this file except in compliance with the License.
 @rem You may obtain a copy of the License at
 @rem
-@rem      http://www.apache.org/licenses/LICENSE-2.0
+@rem      https://www.apache.org/licenses/LICENSE-2.0
 @rem
 @rem Unless required by applicable law or agreed to in writing, software
 @rem distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/kotlin/io/heapy/kotbot/Application.kt
+++ b/src/main/kotlin/io/heapy/kotbot/Application.kt
@@ -22,13 +22,8 @@ object Application {
         val store = InMemoryStore()
         val state = State()
         val rules = listOfNotNull(
-            deleteJoinRule,
-            deleteSpamRule,
-            defaultDeleteHelloRule,
-            classLoader.getResource("contains.txt")?.let { resourceDeleteSwearingRule(it) },
-
-            getIdRule(state),
-            admRule(store, state),
+            policyRules(classLoader.getResource("contains.txt")),
+            devRules(store, state),
             familyRules(store, state)
         )
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="debug">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>


### PR DESCRIPTION
This is very preliminary state of my vision on chat families.

Things to look at:
* `BotStore` backed by `InMemoryStore`: persistent storage
* `State`: throw-away state mainly needed to keep some stuff in between connected updates.
* `BotQueries` backed by `TelegramApiQueries`: the way to call (and mock in future) checks like whether the user is admin etc.
* Failed actions can be repeated on demand.
* Family management rules.

On the latter (it mostly works as described in #3):
* Sending `/family` in a chat creates a family and makes it family admin
* Sending `/family-add` in family admin chat sends a deep link. Clicking it and selecting a chat adds it to family, additionally waiting for granting of admin rights.
* Removing bot from chat removes this chat from corresponding family.
* Sending `/report` in a family chat posts a message to family admin chat.

The implementation definitely needs some love, I'm not entirely pleased with the code, many corner cases are missed, so this is just to get some feedback from you, @IRus. Let me know if you have any thoughts on this, or whether I should wait for anything on your side before continuing.