### PR TITLE
Alternative `supertypeMapping` computation

### DIFF
--- a/core-gen/src/main/kotlin/Generate.kt
+++ b/core-gen/src/main/kotlin/Generate.kt
@@ -12,8 +12,8 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
-import kotlinx.serialization.json.Json
 import kotlin.io.path.Path
+import kotlinx.serialization.json.Json
 
 fun main() {
     // https://ark0f.github.io/tg-bot-api/custom.json
@@ -27,13 +27,10 @@ fun main() {
 }
 
 fun TelegramApi.generate() {
-    val supertypeMapping = objects.filterIsInstance<AnyOfObject>()
+    val supertypeMapping = objects
+        .filterIsInstance<AnyOfObject>()
         .flatMap { anyOf ->
-            anyOf.any_of
-                .map { apiType -> apiType as ReferenceApiType }
-                .map { apiType -> apiType.reference }
-                .associateWith { anyOf.name }
-                .map { it.key to it.value }
+            anyOf.any_of.map { (it as ReferenceApiType).reference to anyOf.name }
         }
         .toMap()
 


### PR DESCRIPTION
I find this way of `supertypeMapping` inexpressive. You don't need that much of operations to compute it. Besides that it is slow. Check out [this test](https://github.com/madhead/kotbot/commit/5976526ae92daadca34bd332967bbff29535d6ee) to ensure the new way is [correct](https://github.com/madhead/kotbot/commit/5976526ae92daadca34bd332967bbff29535d6ee#diff-47fc25bba6f8cedc66a1175a73a9a3f4658295a317efd5d8abb1dabf35f17dbf) and [fast](https://github.com/madhead/kotbot/commit/5976526ae92daadca34bd332967bbff29535d6ee#diff-a2554dfc17400fc45f3ec9e7a17bbaab73c1b0d2a549e22bf1da30962415bb40). Benchmark results for lazies below :point_down: 

```
Benchmark                                        Mode      Cnt    Score     Error   Units
SupertypeMappingBenchmark.neuf                  thrpt       15    0.588 ±   0.056  ops/us
SupertypeMappingBenchmark.vieux                 thrpt       15    0.278 ±   0.008  ops/us
SupertypeMappingBenchmark.neuf                   avgt       15    1.837 ±   0.048   us/op
SupertypeMappingBenchmark.vieux                  avgt       15    3.700 ±   0.191   us/op
SupertypeMappingBenchmark.neuf                 sample  4913744    1.947 ±   0.005   us/op
SupertypeMappingBenchmark.neuf:neuf·p0.00      sample             1.626             us/op
SupertypeMappingBenchmark.neuf:neuf·p0.50      sample             1.872             us/op
SupertypeMappingBenchmark.neuf:neuf·p0.90      sample             2.030             us/op
SupertypeMappingBenchmark.neuf:neuf·p0.95      sample             2.180             us/op
SupertypeMappingBenchmark.neuf:neuf·p0.99      sample             3.380             us/op
SupertypeMappingBenchmark.neuf:neuf·p0.999     sample             6.232             us/op
SupertypeMappingBenchmark.neuf:neuf·p0.9999    sample            16.576             us/op
SupertypeMappingBenchmark.neuf:neuf·p1.00      sample           973.824             us/op
SupertypeMappingBenchmark.vieux                sample  5050866    3.742 ±   0.006   us/op
SupertypeMappingBenchmark.vieux:vieux·p0.00    sample             3.268             us/op
SupertypeMappingBenchmark.vieux:vieux·p0.50    sample             3.648             us/op
SupertypeMappingBenchmark.vieux:vieux·p0.90    sample             3.860             us/op
SupertypeMappingBenchmark.vieux:vieux·p0.95    sample             3.980             us/op
SupertypeMappingBenchmark.vieux:vieux·p0.99    sample             6.008             us/op
SupertypeMappingBenchmark.vieux:vieux·p0.999   sample             8.576             us/op
SupertypeMappingBenchmark.vieux:vieux·p0.9999  sample            21.344             us/op
SupertypeMappingBenchmark.vieux:vieux·p1.00    sample           964.608             us/op
SupertypeMappingBenchmark.neuf                     ss        3   89.968 ± 150.586   us/op
SupertypeMappingBenchmark.vieux                    ss        3  138.811 ± 586.554   us/op
```

(`neuf` == `new`, `vieux` == `old` because Java does not like the `new` word).