### PR TITLE
Migrate OpenAI client to the official openai-java SDK

### DIFF
--- a/tgkotbot/build.gradle.kts
+++ b/tgkotbot/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
 
     implementation(libs.micrometer.prometheus)
 
+    implementation(libs.openai.java)
+
     ksp(libs.komok.tech.di)
     implementation(libs.komok.tech.di.lib)
     implementation(libs.komok.tech.config)

--- a/tgkotbot/src/main/kotlin/io/heapy/kotbot/bot/admin/UserNoteService.kt
+++ b/tgkotbot/src/main/kotlin/io/heapy/kotbot/bot/admin/UserNoteService.kt
@@ -72,80 +72,32 @@ class UserNoteService(
     private suspend fun extractBatchFacts(messages: List<String>): String {
         val messagesText = messages.joinToString("\n---\n")
         return gptApi.complete(
-            GptApi.ChatCompletionRequest(
-                model = "gpt-5.4-mini",
-                messages = listOf(
-                    GptApi.ChatCompletionRequest.Message(
-                        role = "system",
-                        content = listOf(
-                            GptApi.ChatCompletionRequest.Content(
-                                type = "text",
-                                text = """
-                                    Analyze Telegram messages to extract facts about the user.
-                                    Focus on: area of expertise, programming topics they work with,
-                                    kind of questions they ask, experience level.
-                                    Be concise and factual. Output plain text, no markdown, 3-5 sentences.
-                                """.trimIndent(),
-                            ),
-                        ),
-                    ),
-                    GptApi.ChatCompletionRequest.Message(
-                        role = "user",
-                        content = listOf(
-                            GptApi.ChatCompletionRequest.Content(
-                                type = "text",
-                                text = "Extract facts about this user from their messages:\n\n$messagesText",
-                            ),
-                        ),
-                    ),
-                ),
-                temperature = 0.3,
-                maxTokens = 512,
-                topP = 1.0,
-                frequencyPenalty = 0.0,
-                presencePenalty = 0.0,
-                responseFormat = GptApi.ChatCompletionRequest.ResponseFormat(type = "text"),
-            ),
-        ).choices.first().message.content
+            model = "gpt-5.4-mini",
+            systemPrompt = """
+                Analyze Telegram messages to extract facts about the user.
+                Focus on: area of expertise, programming topics they work with,
+                kind of questions they ask, experience level.
+                Be concise and factual. Output plain text, no markdown, 3-5 sentences.
+            """.trimIndent(),
+            userPrompt = "Extract facts about this user from their messages:\n\n$messagesText",
+            temperature = 0.3,
+            maxTokens = 512,
+        )
     }
 
     private suspend fun combineSummaries(summaries: List<String>): String {
         val summariesText = summaries.joinToString("\n\n---\n\n")
         return gptApi.complete(
-            GptApi.ChatCompletionRequest(
-                model = "gpt-5.4-mini",
-                messages = listOf(
-                    GptApi.ChatCompletionRequest.Message(
-                        role = "system",
-                        content = listOf(
-                            GptApi.ChatCompletionRequest.Content(
-                                type = "text",
-                                text = """
-                                    Combine multiple observations about a Telegram user into a single concise profile.
-                                    Focus on: area of expertise, programming topics, kind of questions asked, experience level.
-                                    Output plain text, no markdown, 3-5 sentences.
-                                """.trimIndent(),
-                            ),
-                        ),
-                    ),
-                    GptApi.ChatCompletionRequest.Message(
-                        role = "user",
-                        content = listOf(
-                            GptApi.ChatCompletionRequest.Content(
-                                type = "text",
-                                text = "Combine these observations into a user profile:\n\n$summariesText",
-                            ),
-                        ),
-                    ),
-                ),
-                temperature = 0.3,
-                maxTokens = 512,
-                topP = 1.0,
-                frequencyPenalty = 0.0,
-                presencePenalty = 0.0,
-                responseFormat = GptApi.ChatCompletionRequest.ResponseFormat(type = "text"),
-            ),
-        ).choices.first().message.content
+            model = "gpt-5.4-mini",
+            systemPrompt = """
+                Combine multiple observations about a Telegram user into a single concise profile.
+                Focus on: area of expertise, programming topics, kind of questions asked, experience level.
+                Output plain text, no markdown, 3-5 sentences.
+            """.trimIndent(),
+            userPrompt = "Combine these observations into a user profile:\n\n$summariesText",
+            temperature = 0.3,
+            maxTokens = 512,
+        )
     }
 
     private companion object {

--- a/tgkotbot/src/main/kotlin/io/heapy/kotbot/infra/openai/GptApi.kt
+++ b/tgkotbot/src/main/kotlin/io/heapy/kotbot/infra/openai/GptApi.kt
@@ -1,18 +1,13 @@
 package io.heapy.kotbot.infra.openai
 
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.request.HttpRequestBuilder
-import io.ktor.client.request.get
-import io.ktor.client.request.headers
-import io.ktor.client.request.post
-import io.ktor.client.request.setBody
-import kotlinx.serialization.SerialName
+import com.openai.client.OpenAIClient
+import com.openai.models.chat.completions.ChatCompletionCreateParams
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 
 class GptApi(
-    private val httpClient: HttpClient,
-    private val gptConfig: GptConfig,
+    private val client: OpenAIClient,
 ) {
     @Serializable
     data class GptConfig(
@@ -20,120 +15,34 @@ class GptApi(
         val organization: String,
     )
 
-    suspend fun getModels(): OpenApiList<Model> {
-        return httpClient
-            .get("https://api.openai.com/v1/models") {
-                openAiHeaders()
-            }
-            .body<OpenApiList<Model>>()
-    }
-
     suspend fun complete(
-        chatCompletionRequest: ChatCompletionRequest,
-    ): ChatCompletionResponse {
-        return httpClient
-            .post("https://api.openai.com/v1/chat/completions") {
-                openAiHeaders()
-                setBody(chatCompletionRequest)
-            }
-            .body<ChatCompletionResponse>()
-    }
+        model: String,
+        systemPrompt: String,
+        userPrompt: String,
+        temperature: Double,
+        maxTokens: Int,
+        topP: Double = 1.0,
+        frequencyPenalty: Double = 0.0,
+        presencePenalty: Double = 0.0,
+    ): String = withContext(Dispatchers.IO) {
+        val params = ChatCompletionCreateParams.builder()
+            .model(model)
+            .addSystemMessage(systemPrompt)
+            .addUserMessage(userPrompt)
+            .temperature(temperature)
+            .maxCompletionTokens(maxTokens.toLong())
+            .topP(topP)
+            .frequencyPenalty(frequencyPenalty)
+            .presencePenalty(presencePenalty)
+            .build()
 
-    private fun HttpRequestBuilder.openAiHeaders() {
-        headers {
-            append("Content-Type", "application/json")
-            append("Authorization", "Bearer ${gptConfig.apiKey}")
-            append("OpenAI-Organization", gptConfig.organization)
-        }
-    }
-
-    @Serializable
-    data class OpenApiList<T>(
-        @SerialName("object")
-        val obj: String,
-        val data: List<T>
-    )
-
-    @Serializable
-    data class Model(
-        val id: String,
-        @SerialName("object")
-        val obj: String,
-        val created: Long,
-        @SerialName("owned_by")
-        val ownedBy: String,
-    )
-
-    @Serializable
-    data class ChatCompletionRequest(
-        val model: String,
-        val messages: List<Message>,
-        val temperature: Double,
-        @SerialName("max_tokens")
-        val maxTokens: Int,
-        @SerialName("top_p")
-        val topP: Double,
-        @SerialName("frequency_penalty")
-        val frequencyPenalty: Double,
-        @SerialName("presence_penalty")
-        val presencePenalty: Double,
-        @SerialName("response_format")
-        val responseFormat: ResponseFormat,
-    ) {
-        @Serializable
-        data class Message(
-            val role: String,
-            val content: List<Content>,
-        )
-
-        @Serializable
-        data class Content(
-            val type: String,
-            val text: String,
-        )
-
-        @Serializable
-        data class ResponseFormat(
-            val type: String,
-        )
-    }
-
-    @Serializable
-    data class ChatCompletionResponse(
-        val id: String,
-        @SerialName("object")
-        val obj: String,
-        val created: Long,
-        val model: String,
-        val choices: List<Choice>,
-        val usage: Usage,
-        @SerialName("system_fingerprint")
-        val systemFingerprint: String,
-    ) {
-        @Serializable
-        data class Choice(
-            val index: Int,
-            val message: Message,
-            val logprobs: Boolean?,
-            @SerialName("finish_reason")
-            val finishReason: String,
-        )
-
-        @Serializable
-        data class Message(
-            val role: String,
-            val content: String,
-            val refusal: String?,
-        )
-
-        @Serializable
-        data class Usage(
-            @SerialName("prompt_tokens")
-            val promptTokens: Int,
-            @SerialName("completion_tokens")
-            val completionTokens: Int,
-            @SerialName("total_tokens")
-            val totalTokens: Int,
-        )
+        client.chat()
+            .completions()
+            .create(params)
+            .choices()
+            .first()
+            .message()
+            .content()
+            .orElse("")
     }
 }

--- a/tgkotbot/src/main/kotlin/io/heapy/kotbot/infra/openai/GptApiModule.kt
+++ b/tgkotbot/src/main/kotlin/io/heapy/kotbot/infra/openai/GptApiModule.kt
@@ -1,12 +1,11 @@
 package io.heapy.kotbot.infra.openai
 
+import com.openai.client.okhttp.OpenAIOkHttpClient
 import io.heapy.komok.tech.config.ConfigurationModule
 import io.heapy.komok.tech.di.lib.Module
-import io.heapy.kotbot.infra.HttpClientModule
 
 @Module
 open class GptApiModule(
-    private val httpClientModule: HttpClientModule,
     private val configurationModule: ConfigurationModule,
 ) {
     open val gptConfig: GptApi.GptConfig by lazy {
@@ -17,10 +16,16 @@ open class GptApiModule(
             )
     }
 
+    open val openAiClient by lazy {
+        OpenAIOkHttpClient.builder()
+            .apiKey(gptConfig.apiKey)
+            .organization(gptConfig.organization)
+            .build()
+    }
+
     open val gptApi by lazy {
         GptApi(
-            httpClient = httpClientModule.httpClient,
-            gptConfig = gptConfig,
+            client = openAiClient,
         )
     }
 

--- a/tgkotbot/src/main/kotlin/io/heapy/kotbot/infra/openai/GptService.kt
+++ b/tgkotbot/src/main/kotlin/io/heapy/kotbot/infra/openai/GptService.kt
@@ -16,44 +16,12 @@ class GptService(
             Provide detailed explanation and links to documentation.
         """.trimIndent()
 
-        val completionResponse = gptApi.complete(
-            GptApi.ChatCompletionRequest(
-                model = "gpt-5.4-mini",
-                messages = listOf(
-                    GptApi.ChatCompletionRequest.Message(
-                        role = "system",
-                        content = listOf(
-                            GptApi.ChatCompletionRequest.Content(
-                                type = "text",
-                                text = systemPrompt,
-                            ),
-                        )
-                    ),
-                    GptApi.ChatCompletionRequest.Message(
-                        role = "user",
-                        content = listOf(
-                            GptApi.ChatCompletionRequest.Content(
-                                type = "text",
-                                text = userPrompt,
-                            ),
-                        )
-                    ),
-                ),
-                temperature = 1.01,
-                maxTokens = 1024,
-                topP = 1.0,
-                frequencyPenalty = 0.0,
-                presencePenalty = 0.0,
-                responseFormat = GptApi.ChatCompletionRequest.ResponseFormat(
-                    type = "text"
-                )
-            )
+        return gptApi.complete(
+            model = "gpt-5.4-mini",
+            systemPrompt = systemPrompt,
+            userPrompt = userPrompt,
+            temperature = 1.01,
+            maxTokens = 1024,
         )
-
-        return completionResponse
-            .choices
-            .first()
-            .message
-            .content
     }
 }


### PR DESCRIPTION
## What

Replaces the hand-rolled Ktor + kotlinx.serialization OpenAI client (`GptApi`) with the official **`com.openai:openai-java`** SDK (4.39.1, already declared in the version catalog).

## Why

Production logs showed `UserNoteService` note generation failing with a misleading error:

```
kotlinx.serialization.MissingFieldException: Fields [id, object, created, model,
choices, usage, system_fingerprint] are required for type ... ChatCompletionResponse,
but they were missing at path: $
```

`GptApi.complete()` called `.body<ChatCompletionResponse>()` unconditionally, with no status check. So any non-2xx response from OpenAI (its body is `{"error": {...}}`) was decoded against the *success* shape and surfaced as a generic "all fields missing" deserialization error — **hiding the real API error** (bad model, auth, quota, etc.).

The official SDK throws typed errors on failure, so the actual OpenAI error now reaches `UserNoteService`'s `catch` and gets logged. It also removes the hand-maintained request/response models.

## Changes

- `GptApi` now wraps `OpenAIClient` and exposes a single `complete(model, systemPrompt, userPrompt, temperature, maxTokens, …)` returning the message content. Blocking SDK calls run on `Dispatchers.IO`.
- `GptApiModule` builds the `OpenAIOkHttpClient` from the existing `"gpt"` config (`apiKey` + `organization`); no longer depends on `HttpClientModule`.
- `GptService` and `UserNoteService` updated to the new signature.
- Removed the unused `getModels()` and all hand-rolled `ChatCompletionRequest`/`ChatCompletionResponse`/`OpenApiList`/`Model` models.
- Mirrors the existing pattern already used by the sibling `tgpt` module (`OpenAiModule`/`OpenAiService`).

## Notes

- Chat Completions semantics, model (`gpt-5.4-mini`), and all params (temperature/topP/penalties/maxTokens) are preserved.
- The separate jOOQ `GarbageMessages` mapping NPE seen in the same logs was fixed independently on `main` (`38f4367`) and is **not** part of this PR.

## Test

- `./gradlew :tgkotbot:compileKotlin :tgkotbot:compileTestKotlin` — green (KSP regenerates the DI builder for the new `GptApiModule` constructor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)