### PR TITLE
Add The Daily Kotlin channel to known chats

### DIFF
--- a/tgkotbot/src/main/resources/reference.conf
+++ b/tgkotbot/src/main/resources/reference.conf
@@ -46,6 +46,9 @@ groups {
     "kotlin_start" = -1001312277000
     "kotlin_meta" = -1001346722152
 
+    # Channels
+    "the_daily_kotlin" = -1001275569487
+
     # Out Of Service
     "belarus_kug" = -1001073967058
 


### PR DESCRIPTION
## Problem

`KnownChatsFilter` makes the bot leave any group/channel not listed in `groups.allowedGroups` (it sends `LeaveChat` + notifies admins on the first update from an unknown chat). The channel [@TheDailyKotlin](https://t.me/TheDailyKotlin) (`-1001275569487`) was never in the list, so KotBot would leave it on the next channel post.

## Fix

Add `@TheDailyKotlin` to `groups.allowedGroups` in `reference.conf`.

Branched off `origin/main` so it contains only this change (local `main` has unrelated in-progress work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)